### PR TITLE
Default AddressSourceAdapter should show translated class names in combo box

### DIFF
--- a/public/js/document/newsletters/addressSourceAdapters/default.js
+++ b/public/js/document/newsletters/addressSourceAdapters/default.js
@@ -45,9 +45,9 @@ pimcore.bundle.newsletter.document.newsletters.addressSourceAdapters.default = C
                 defaults: {labelWidth: 200},
                 items: [
                     {
-                        xtype: "combo",
-                        name: "class",
-                        fieldLabel: t("class"),
+                        xtype: 'combo',
+                        name: 'class',
+                        fieldLabel: t('class'),
                         triggerAction: 'all',
                         editable: false,
                         store: new Ext.data.Store({
@@ -60,10 +60,19 @@ pimcore.bundle.newsletter.document.newsletters.addressSourceAdapters.default = C
                                     rootProperty: 'data'
                                 }
                             },
-                            fields: ["name"]
+                            fields: [
+                                'name',
+                                {
+                                    name: 'translatedName',
+                                    convert: function(v, rec){
+                                        return t(rec.data.name);
+                                    },
+                                    depends : ['name']
+                                }
+                            ]
                         }),
                         width: 600,
-                        displayField: 'name',
+                        displayField: 'translatedName',
                         valueField: 'name'
                     },{
                         xtype: "textfield",


### PR DESCRIPTION
Before:
![image](https://github.com/pimcore/newsletter-bundle/assets/998558/4d291ceb-492a-441d-a35e-5eb9f9fec727)

After:
![image](https://github.com/pimcore/newsletter-bundle/assets/998558/df54e6d1-1758-413c-a7f8-6c9644d7ab16)
