### PR TITLE
[Bug] if an E-Mail address does not contain a dot

### DIFF
--- a/src/Tool/Newsletter.php
+++ b/src/Tool/Newsletter.php
@@ -205,7 +205,8 @@ class Newsletter
     protected static function obfuscateEmail(string $email): string
     {
         $offset = strrpos($email, '.');
-        if ($offset !== false) {
+	$offsetAt = strrpos($email, '@');
+        if ($offset !== false && $offsetAt !== false && $offset > $offsetAt) {
             return substr_replace($email, '.xxx', $offset);
         }
         // if the email address is too broken to be obfuscated, just return it

--- a/src/Tool/Newsletter.php
+++ b/src/Tool/Newsletter.php
@@ -207,7 +207,7 @@ class Newsletter
         $offset = strrpos($email, '.');
 	$offsetAt = strrpos($email, '@');
         if ($offset !== false && $offsetAt !== false && $offset > $offsetAt) {
-            return substr_replace($email, '.xxx', $offset);
+            return substr_replace($email, '.xxxx', $offset);
         }
         // if the email address is too broken to be obfuscated, just return it
         return $email;

--- a/src/Tool/Newsletter.php
+++ b/src/Tool/Newsletter.php
@@ -205,7 +205,7 @@ class Newsletter
     protected static function obfuscateEmail(string $email): string
     {
         $offset = strrpos($email, '.');
-	$offsetAt = strrpos($email, '@');
+	    $offsetAt = strrpos($email, '@');
         if ($offset !== false && $offsetAt !== false && $offset > $offsetAt) {
             return substr_replace($email, '.xxxx', $offset);
         }

--- a/src/Tool/Newsletter.php
+++ b/src/Tool/Newsletter.php
@@ -204,7 +204,12 @@ class Newsletter
 
     protected static function obfuscateEmail(string $email): string
     {
-        return substr_replace($email, '.xxx', strrpos($email, '.'));
+        $offset = strrpos($email, '.');
+        if ($offset !== false) {
+            return substr_replace($email, '.xxx', $offset);
+        }
+        // if the email address is too broken to be obfuscated, just return it
+        return $email;
     }
 
     protected function getClassName(): string


### PR DESCRIPTION
If an invalid email address does not have a dot in it, we cannot obfuscate it