### PR TITLE
Adding perspectives permissions. Added addBlankNewsletter permission.

### DIFF
--- a/public/js/startup.js
+++ b/public/js/startup.js
@@ -2,10 +2,34 @@ pimcore.registerNS("pimcore.bundle.newsletter.startup");
 
 pimcore.bundle.newsletter.startup = Class.create({
     type: 'newsletter',
-
+    perspectivePermissions: [
+        'items.addNewsletter',
+        'items.addBlankNewsletter'  
+    ],
+ 
     initialize: function () {
+        if (pimcore.events.onPerspectiveEditorLoadPermissions) {
+            document.addEventListener(pimcore.events.onPerspectiveEditorLoadPermissions, this.perspectiveEditorLoadPermissions.bind(this));
+        }
+
         document.addEventListener(pimcore.events.prepareDocumentTreeContextMenu, this.onPrepareDocumentTreeContextMenu.bind(this));
     },
+
+    onPerspectiveEditorLoadPermissions: function (e) {
+        const context = e.detail.context;
+        const menu = e.detail.menu;
+        const permissions = e.detail.permissions;
+
+        if(context === 'customViewContextMenu' &&
+            menu === 'document'
+        ) {
+            this.perspectivePermissions.forEach((permission) => {
+                if (permissions[context][menu].indexOf(permission) === -1) {
+                    permissions[context][menu].push(permission);
+                }
+            });
+        }
+    } 
 
     onPrepareDocumentTreeContextMenu: function (e) {
         let user = pimcore.globalmanager.get("user");

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -1,5 +1,5 @@
 plugin_pimcore_perspectiveeditor_document_items_addNewsletter: "Add Newsletter"
-plugin_pimcore_perspectiveeditor_document_items_addBlankNewsletter: "Add Blank Newsletter"
+plugin_pimcore_perspectiveeditor_document_items_addBlankNewsletter: "Add Newsletter > Blank"
 newsletter: 'Newsletter'
 newsletters: 'Newsletters'
 add_newsletter: 'Add Newsletter'

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -1,3 +1,5 @@
+plugin_pimcore_perspectiveeditor_document_items_addNewsletter: "Add Newsletter"
+plugin_pimcore_perspectiveeditor_document_items_addBlankNewsletter: "Add Blank Newsletter"
 newsletter: 'Newsletter'
 newsletters: 'Newsletters'
 add_newsletter: 'Add Newsletter'


### PR DESCRIPTION
Solves 2 things from Persepective Editor bundle:

- Related  https://github.com/pimcore/perspective-editor/pull/169 and moving permission to bundle.
- Related https://github.com/pimcore/perspective-editor/issues/142 - Added permission to manage "Blank" menu item in context menu.

Please review,