### PR TITLE
Symfony 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "doctrine/dbal": "^4.0",
     "pimcore/generic-data-index-bundle": "^2.1",
     "pimcore/admin-ui-classic-bundle": "^2.0",
-    "pimcore/pimcore": "^12.0"
+    "pimcore/pimcore": "^12.3"
   },
   "require-dev": {
     "phpstan/phpstan": "^1.12.15",

--- a/src/Controller/Document/NewsletterController.php
+++ b/src/Controller/Document/NewsletterController.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\NewsletterBundle\Controller\Document;
 
-use Pimcore\Helper\ParameterBagHelper;
 use Exception;
 use Pimcore;
 use Pimcore\Bundle\AdminBundle\Controller\Admin\Document\DocumentControllerBase;
@@ -23,6 +22,7 @@ use Pimcore\Bundle\NewsletterBundle\Model\DataObject\ClassDefinition\Data\Newsle
 use Pimcore\Bundle\NewsletterBundle\Model\DataObject\ClassDefinition\Data\NewsletterConfirmed;
 use Pimcore\Bundle\NewsletterBundle\Model\Document\Newsletter;
 use Pimcore\Bundle\NewsletterBundle\Tool\Newsletter as NewsletterTool;
+use Pimcore\Helper\ParameterBagHelper;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Email;
 use Pimcore\Model\DataObject\ClassDefinition\Listing;
 use Pimcore\Model\Document;

--- a/src/Controller/Document/NewsletterController.php
+++ b/src/Controller/Document/NewsletterController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\NewsletterBundle\Controller\Document;
 
+use Pimcore\Helper\ParameterBagHelper;
 use Exception;
 use Pimcore;
 use Pimcore\Bundle\AdminBundle\Controller\Admin\Document\DocumentControllerBase;
@@ -47,7 +48,7 @@ class NewsletterController extends DocumentControllerBase
     {
         $this->checkPermission('newsletters');
 
-        $email = Newsletter::getById($request->query->getInt('id'));
+        $email = Newsletter::getById(ParameterBagHelper::getInt($request->query, 'id'));
 
         if (!$email) {
             throw $this->createNotFoundException('Document not found');
@@ -89,7 +90,7 @@ class NewsletterController extends DocumentControllerBase
     {
         $this->checkPermission('newsletters');
 
-        $page = Newsletter::getById($request->request->getInt('id'));
+        $page = Newsletter::getById(ParameterBagHelper::getInt($request->request, 'id'));
         if (!$page) {
             throw $this->createNotFoundException('Document not found');
         }
@@ -235,7 +236,7 @@ class NewsletterController extends DocumentControllerBase
     {
         $this->checkPermission('newsletters');
 
-        $document = Newsletter::getById($request->query->getInt('id'));
+        $document = Newsletter::getById(ParameterBagHelper::getInt($request->query, 'id'));
         if (!$document) {
             throw $this->createNotFoundException('Newsletter not found');
         }
@@ -252,7 +253,7 @@ class NewsletterController extends DocumentControllerBase
     {
         $this->checkPermission('newsletters');
 
-        $document = Newsletter::getById($request->request->getInt('id'));
+        $document = Newsletter::getById(ParameterBagHelper::getInt($request->request, 'id'));
         if (!$document) {
             throw $this->createNotFoundException('Newsletter not found');
         }
@@ -271,7 +272,7 @@ class NewsletterController extends DocumentControllerBase
     {
         $this->checkPermission('newsletters');
 
-        $document = Newsletter::getById($request->request->getInt('id'));
+        $document = Newsletter::getById(ParameterBagHelper::getInt($request->request, 'id'));
         if (!$document) {
             throw $this->createNotFoundException('Newsletter not found');
         }
@@ -328,7 +329,7 @@ class NewsletterController extends DocumentControllerBase
     {
         $this->checkPermission('newsletters');
 
-        $document = Newsletter::getById($request->request->getInt('id'));
+        $document = Newsletter::getById(ParameterBagHelper::getInt($request->request, 'id'));
         if (!$document) {
             throw $this->createNotFoundException('Newsletter not found');
         }


### PR DESCRIPTION
This pull request refactors how request parameters are retrieved in the `NewsletterController` to improve consistency and reliability. The main change is replacing direct calls to `$request->query->getInt('id')` and `$request->request->getInt('id')` with the helper method `ParameterBagHelper::getInt`, ensuring safer and more uniform parameter handling across all relevant controller actions.

**Parameter handling improvements:**

* Replaced all instances of `$request->query->getInt('id')` and `$request->request->getInt('id')` with `ParameterBagHelper::getInt` in the following controller methods: `getDataByIdAction`, `saveAction`, `getSendStatusAction`, `stopSendAction`, `sendAction`, and `sendTestAction` within `NewsletterController.php`. [[1]](diffhunk://#diff-c6e02f6fcd19b886f778b05a3b6dda18f5a8f6c6c876fdbc630ba4b2f3f74e55L50-R51) [[2]](diffhunk://#diff-c6e02f6fcd19b886f778b05a3b6dda18f5a8f6c6c876fdbc630ba4b2f3f74e55L92-R93) [[3]](diffhunk://#diff-c6e02f6fcd19b886f778b05a3b6dda18f5a8f6c6c876fdbc630ba4b2f3f74e55L238-R239) [[4]](diffhunk://#diff-c6e02f6fcd19b886f778b05a3b6dda18f5a8f6c6c876fdbc630ba4b2f3f74e55L255-R256) [[5]](diffhunk://#diff-c6e02f6fcd19b886f778b05a3b6dda18f5a8f6c6c876fdbc630ba4b2f3f74e55L274-R275) [[6]](diffhunk://#diff-c6e02f6fcd19b886f778b05a3b6dda18f5a8f6c6c876fdbc630ba4b2f3f74e55L331-R332)

**Dependency update:**

* Added the import statement for `Pimcore\Helper\ParameterBagHelper` at the top of `NewsletterController.php` to support the new parameter retrieval method.