### PR TITLE
chore: replace @reusable-workflows with @main

### DIFF
--- a/.github/workflows/new-docs.yml
+++ b/.github/workflows/new-docs.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   docs:
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@reusable-workflows
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@main
     with:
       docs_path: "doc"
     secrets:


### PR DESCRIPTION
This PR replaces all occurrences of `@reusable-workflows` with `@main` across the repository.