### PR TITLE
Sync non-matrix workflows with 2.3 (#1305)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cla-workflow:
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-cla-check.yaml@v1.3.0
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-cla-check.yaml@main
     if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
     secrets:
       CLA_ACTION_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}

--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -1,35 +1,23 @@
 name: "PHP-CS-Fixer"
 
 on:
-    pull_request_target:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "feature-*"
-    push:
-        branches:
-            - "[0-9]+.[0-9]+"
-            - "[0-9]+.x"
-            - "*_actions"
-            - "feature-*"
+  workflow_dispatch:
+  push:
+    branches:
+      - "[0-9]+.[0-9]+"
+      - "[0-9]+.x"
+      - "*_actions"
+      - "feature-*"
 
 permissions:
-    contents: read
+  contents: write
 
 jobs:
-    php-cs-fixer:
-        permissions:
-            contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  ref: ${{ github.event.pull_request.head.ref }}
-                  repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-            - name: PHP-CS-Fixer
-              uses: docker://oskarstark/php-cs-fixer-ga:latest
-
-            - uses: stefanzweifel/git-auto-commit-action@v5
-              with:
-                  commit_message: Apply php-cs-fixer changes
+  php-style:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
+    with:
+      head_ref: ${{ github.head_ref || github.ref_name }}
+      repository: ${{ github.repository }}
+      config_file: ".php-cs-fixer.dist.php"
+    secrets:
+      PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}


### PR DESCRIPTION
Part of product-management#1305, Wave 3 (2024.4 / LTS branches). Same recipe as the previous waves. Reference branch: `2.3`. Every adopted file is byte-identical to it. Codeception / static-analysis workflows untouched (matrix class).

Changes:` adopt:cla.yml adopt:php-cs-fixer.yaml`

**PCL line — no forward-merge will follow** (cross-license boundary: changes travel by cherry-pick only, and PCL lines are separate release tracks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)